### PR TITLE
Add list_races and get_race_summary MCP tools

### DIFF
--- a/docs/maintainers/adding-mcp-tools.md
+++ b/docs/maintainers/adding-mcp-tools.md
@@ -1,0 +1,188 @@
+# Adding MCP Tools
+
+This guide walks through the process of adding new tools to the Pyrox MCP
+server. It uses the `list_races` and `get_race_summary` tools as a worked
+example.
+
+## Architecture
+
+Every MCP tool passes through five layers:
+
+```
+ReportingQueries method  (reporting_queries.py)
+        |
+   REST endpoint          (app.py)
+        |
+   MCP tool function      (mcp_tools.py)
+        |
+   Tool registration      (mcp_app.py)
+        |
+   Smoke test set          (scripts/smoke_mcp.py)
+```
+
+The MCP tool functions never touch the database directly. They call the REST
+API in-process via `TestClient` (no network socket), so they get the same
+validation, error mapping, and logging as external HTTP callers.
+
+## Step-by-step
+
+### 1. Add a query method to `ReportingQueries`
+
+All data access lives in `reporting_queries.py`. Add a new method to the
+`ReportingQueries` class.
+
+**Example: `list_races`**
+
+```python
+def list_races(self, *, season=None, gender=None) -> dict:
+    con = self.connection()
+    clauses, params = [], []
+
+    if season is not None:
+        clauses.append("season = ?")
+        params.append(int(season))
+    if normalize_optional_text(gender) is not None:
+        gc, gp = _gender_filter(gender)
+        clauses.extend(gc)
+        params.extend(gp)
+
+    where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    df = con.execute(f"""
+        SELECT event_name, event_id, location, season, year,
+               COUNT(*) AS participant_count
+        FROM race_results {where_sql}
+        GROUP BY event_name, event_id, location, season, year
+        ORDER BY season DESC, year DESC, lower(location)
+    """, params).fetchdf()
+
+    return {"filters": {...}, "count": len(df), "races": df_to_records(df)}
+```
+
+**Key conventions:**
+
+- Use keyword-only arguments (`*` separator).
+- Normalize text inputs with `normalize_optional_text()`.
+- Handle gender M/male and F/female equivalence via `_gender_filter()`.
+- Return a dict with an echo of the filters applied, a count, and the data.
+- Raise `ReportingNotFoundError` (404) or `ReportingQueryError` (400) for
+  expected failures; `app.py` maps these to HTTP status codes.
+- Reuse existing helpers: `_describe_times()` for summary stats,
+  `df_to_records()` for DataFrame-to-JSON conversion, `_build_histogram()`
+  for distributions.
+
+### 2. Add a REST endpoint in `app.py`
+
+Wire the query method to a FastAPI route. The endpoint handles HTTP-specific
+concerns (parameter validation via `Query`, error mapping via `_query()`).
+
+```python
+@app.get("/api/races")
+def list_races(
+    season: Optional[int] = Query(None, ge=1),
+    gender: Optional[str] = Query(None),
+) -> dict:
+    return _query(queries.list_races, season=season, gender=gender)
+```
+
+The `_query()` wrapper catches exceptions from the query layer and converts
+them to `HTTPException` responses.
+
+### 3. Add an MCP tool function in `mcp_tools.py`
+
+Each tool is a plain Python function that calls the REST endpoint via `_get()`.
+
+```python
+def list_races(season=None, gender=None) -> dict:
+    """Available races with participant counts, optionally filtered by season or gender.
+
+    Returns distinct races showing event name, location, season, year, and
+    how many athletes participated. Use this to discover which races exist
+    before requesting a race summary.
+    """
+    return _get("/api/races", {"season": season, "gender": gender})
+```
+
+**The docstring is the tool description** that LLM callers see. Write it to
+guide the model on when and how to use the tool. Mention related tools
+(e.g., "use `list_races` first to discover valid season + location pairs").
+
+### 4. Register the tool in `mcp_app.py`
+
+Add a tuple to the `TOOLS` constant:
+
+```python
+TOOLS = (
+    ...
+    (mcp_tools.list_races, "List available races"),
+    ...
+)
+```
+
+The title string appears in MCP client UIs. All tools share the `READ_ONLY_TOOL`
+annotation (read-only, non-destructive, idempotent, closed-world).
+
+### 5. Update the smoke test
+
+Add the tool name to `EXPECTED_TOOL_NAMES` in `scripts/smoke_mcp.py`:
+
+```python
+EXPECTED_TOOL_NAMES = frozenset({
+    ...
+    "list_races",
+    ...
+})
+```
+
+### 6. Write tests in `tests/test_mcp_tools.py`
+
+Tests call the tool functions directly (no MCP session needed). Seed a
+temporary DuckDB, point `PYROX_DUCKDB_PATH` at it via `monkeypatch`, and
+assert on the returned dict.
+
+```python
+def test_list_races_returns_distinct_races_with_counts(tmp_path, monkeypatch):
+    db_path = tmp_path / "mcp-races.db"
+    con = _create_db(db_path)
+    _seed_races(con)
+    con.close()
+
+    monkeypatch.setenv("PYROX_DUCKDB_PATH", str(db_path))
+    result = mcp_tools.list_races()
+
+    assert result["count"] == 3
+    london = next(r for r in result["races"] if r["location"] == "london")
+    assert london["participant_count"] == 3
+```
+
+Always update `test_mcp_server_registers_expected_tools` to include the new
+tool names.
+
+## Design principles
+
+1. **Intent-shaped tools, not raw SQL.** Each tool answers a specific question
+   an LLM might ask. Never expose a generic `query(sql)` tool.
+
+2. **Errors as dicts, not exceptions.** The `_get()` helper converts non-200
+   responses to `{"error": ..., "status_code": ...}` so the LLM can reason
+   about failures without the MCP session crashing.
+
+3. **Server-side aggregation.** Distributions, percentiles, and summary stats
+   are computed in the query layer, not by the LLM. This keeps answers
+   deterministic and avoids dumping large DataFrames into model context.
+
+4. **Reuse helpers.** `_describe_times()` returns
+   `{count, min, max, mean, median, p10, p90}` for any numeric column.
+   `_gender_filter()` handles M/male F/female equivalence. `df_to_records()`
+   converts DataFrames to JSON-safe record lists.
+
+5. **Docstrings are LLM-facing.** The tool's docstring becomes its description
+   in the MCP tool listing. Write it for the model: explain what the tool
+   does, when to use it, and which tool to call first.
+
+## Verification checklist
+
+- [ ] `pytest tests/test_mcp_tools.py -v` passes (new + existing tests)
+- [ ] `pytest tests/ -v` shows no regressions
+- [ ] New tool appears in `test_mcp_server_registers_expected_tools`
+- [ ] New tool name is in `EXPECTED_TOOL_NAMES` in `smoke_mcp.py`
+- [ ] Tool docstring clearly describes purpose and usage flow

--- a/pyrox_api_service/app.py
+++ b/pyrox_api_service/app.py
@@ -154,6 +154,40 @@ def filter_options(
     )
 
 
+@app.get("/api/races")
+def list_races(
+    season: Optional[int] = Query(None, ge=1),
+    gender: Optional[str] = Query(None),
+) -> dict:
+    """Return distinct races with participant counts."""
+    return _query(
+        queries.list_races,
+        season=season,
+        gender=gender,
+    )
+
+
+@app.get("/api/race-summary")
+def race_summary(
+    season: int = Query(..., ge=1),
+    location: str = Query(..., min_length=1),
+    gender: Optional[str] = Query(None),
+    division: Optional[str] = Query(None),
+    age_group: Optional[str] = Query(None),
+    top_percentile: Optional[float] = Query(None, gt=0, lt=100),
+) -> dict:
+    """Return summary statistics across all timing metrics for one race."""
+    return _query(
+        queries.race_summary,
+        season=season,
+        location=location,
+        gender=gender,
+        division=division,
+        age_group=age_group,
+        top_percentile=top_percentile,
+    )
+
+
 @app.get("/api/reports/{result_id}")
 def report_for_result(
     result_id: str,

--- a/pyrox_api_service/mcp_app.py
+++ b/pyrox_api_service/mcp_app.py
@@ -63,8 +63,10 @@ READ_ONLY_TOOL = ToolAnnotations(
 # labels and safe-use hints for model-controlled tool calls.
 TOOLS = (
     (mcp_tools.list_filters, "List Pyrox filters"),
+    (mcp_tools.list_races, "List available races"),
     (mcp_tools.find_athlete, "Find athlete results"),
     (mcp_tools.get_distribution, "Get cohort distribution"),
+    (mcp_tools.get_race_summary, "Get race summary stats"),
     (mcp_tools.get_rankings, "Get rankings"),
     (mcp_tools.get_race_report, "Get race report"),
     (mcp_tools.get_deepdive, "Get location deep dive"),

--- a/pyrox_api_service/mcp_tools.py
+++ b/pyrox_api_service/mcp_tools.py
@@ -177,3 +177,49 @@ def list_filters(
         "/api/filter-options",
         {"season": season, "division": division, "gender": gender},
     )
+
+
+def list_races(
+    season: Optional[int] = None,
+    gender: Optional[str] = None,
+) -> dict:
+    """Available races with participant counts, optionally filtered by season or gender.
+
+    Returns distinct races showing event name, location, season, year, and
+    how many athletes participated. Use this to discover which races exist
+    before requesting a race summary.
+    """
+    return _get(
+        "/api/races",
+        {"season": season, "gender": gender},
+    )
+
+
+def get_race_summary(
+    season: int,
+    location: str,
+    gender: Optional[str] = None,
+    division: Optional[str] = None,
+    age_group: Optional[str] = None,
+    top_percentile: Optional[float] = None,
+) -> dict:
+    """Summary statistics across all timing segments for a specific race.
+
+    Returns count, min, max, mean, median, p10, p90 for every timing
+    segment (total, each run, each station, aggregate run/work/roxzone).
+
+    Use `list_races` first to discover valid season + location pairs.
+    Set `top_percentile` (e.g. 10) to restrict to the fastest N percent of
+    finishers and see what their segment times look like.
+    """
+    return _get(
+        "/api/race-summary",
+        {
+            "season": season,
+            "location": location,
+            "gender": gender,
+            "division": division,
+            "age_group": age_group,
+            "top_percentile": top_percentile,
+        },
+    )

--- a/pyrox_api_service/reporting_queries.py
+++ b/pyrox_api_service/reporting_queries.py
@@ -578,6 +578,152 @@ class ReportingQueries:
             "age_groups": _clean_distinct_values(age_groups_df, "age_group"),
         }
 
+    def list_races(
+        self,
+        *,
+        season: Optional[int] = None,
+        gender: Optional[str] = None,
+    ) -> dict:
+        """Return distinct races with participant counts.
+
+        Each race is identified by (event_name, event_id, location, season, year).
+        Optional *season* and *gender* filters scope the results; when *gender* is
+        used the participant count reflects only matching athletes.
+        """
+        con = self.connection()
+        clauses: list[str] = []
+        params: list[object] = []
+
+        if season is not None:
+            clauses.append("season = ?")
+            params.append(int(season))
+
+        normalized_gender = normalize_optional_text(gender)
+        if normalized_gender is not None:
+            gender_clauses, gender_params = _gender_filter(normalized_gender)
+            clauses.extend(gender_clauses)
+            params.extend(gender_params)
+
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        df = con.execute(
+            f"""
+            SELECT event_name, event_id, location, season, year,
+                   COUNT(*) AS participant_count
+            FROM race_results
+            {where_sql}
+            GROUP BY event_name, event_id, location, season, year
+            ORDER BY season DESC, year DESC, lower(location) ASC
+            """,
+            params,
+        ).fetchdf()
+
+        return {
+            "filters": {"season": season, "gender": normalized_gender},
+            "count": len(df),
+            "races": df_to_records(df),
+        }
+
+    def race_summary(
+        self,
+        *,
+        season: int,
+        location: str,
+        gender: Optional[str] = None,
+        division: Optional[str] = None,
+        age_group: Optional[str] = None,
+        top_percentile: Optional[float] = None,
+    ) -> dict:
+        """Return summary statistics across all timing segments for one race.
+
+        The race is identified by *season* + *location*. Optional cohort filters
+        narrow the population. When *top_percentile* is set (e.g. ``10``), only
+        athletes whose ``total_time_min`` falls at or below the Nth-percentile
+        threshold are included (lower time = faster = "top").
+        """
+        con = self.connection()
+        clauses = ["season = ?", "lower(location) = ?"]
+        params: list[object] = [int(season), str(location).strip().casefold()]
+
+        normalized_division = normalize_optional_text(division)
+        if normalized_division is not None:
+            clauses.append("lower(division) = ?")
+            params.append(normalized_division.casefold())
+
+        normalized_gender = normalize_optional_text(gender)
+        if normalized_gender is not None:
+            gender_clauses, gender_params = _gender_filter(normalized_gender)
+            clauses.extend(gender_clauses)
+            params.extend(gender_params)
+
+        normalized_age_group = normalize_optional_text(age_group)
+        if normalized_age_group is not None:
+            clauses.append("lower(age_group) = ?")
+            params.append(normalized_age_group.casefold())
+
+        where_sql = " AND ".join(clauses)
+        df = con.execute(
+            f"SELECT * FROM race_results WHERE {where_sql}",
+            params,
+        ).fetchdf()
+
+        total_count = len(df)
+        if total_count == 0:
+            raise ReportingNotFoundError(
+                f"No results for season={season}, location={location}"
+            )
+
+        percentile_threshold = None
+        if top_percentile is not None:
+            if not (0 < top_percentile < 100):
+                raise ReportingQueryError(
+                    "top_percentile must be between 0 and 100 (exclusive)."
+                )
+            valid_totals = pd.to_numeric(df["total_time_min"], errors="coerce").dropna()
+            if valid_totals.empty:
+                raise ReportingQueryError(
+                    "No valid total_time_min values for percentile filtering."
+                )
+            percentile_threshold = float(valid_totals.quantile(top_percentile / 100.0))
+            df = df[pd.to_numeric(df["total_time_min"], errors="coerce") <= percentile_threshold]
+
+        filtered_count = len(df)
+
+        segments: list[dict] = []
+        for cfg in SEGMENT_CONFIG:
+            stats = _describe_times(df, cfg["key"])
+            if stats is None:
+                continue
+            segments.append({
+                "key": cfg["key"],
+                "label": cfg["label"],
+                "group": cfg["group"],
+                "stats": stats,
+            })
+
+        for col, label, group in (
+            ("run_time_min", "Total Run", "aggregate"),
+            ("work_time_min", "Total Work", "aggregate"),
+            ("roxzone_time_min", "Total Roxzone", "aggregate"),
+        ):
+            stats = _describe_times(df, col)
+            if stats is not None:
+                segments.append({"key": col, "label": label, "group": group, "stats": stats})
+
+        return {
+            "filters": {
+                "season": season,
+                "location": location,
+                "gender": normalized_gender,
+                "division": normalized_division,
+                "age_group": normalized_age_group,
+                "top_percentile": top_percentile,
+            },
+            "total_count": total_count,
+            "filtered_count": filtered_count,
+            "percentile_threshold_min": percentile_threshold,
+            "segments": segments,
+        }
+
     def report_for_result(
         self,
         *,

--- a/scripts/smoke_mcp.py
+++ b/scripts/smoke_mcp.py
@@ -19,8 +19,10 @@ DEFAULT_TIMEOUT_SECONDS = 20.0
 EXPECTED_TOOL_NAMES = frozenset(
     {
         "list_filters",
+        "list_races",
         "find_athlete",
         "get_distribution",
+        "get_race_summary",
         "get_rankings",
         "get_race_report",
         "get_deepdive",

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -179,6 +179,146 @@ def test_list_filters_returns_distinct_cohort_values(tmp_path, monkeypatch):
     assert set(result["divisions"]) == {"open", "pro"}
 
 
+def _seed_races(con: duckdb.DuckDBPyConnection) -> None:
+    con.execute(
+        """
+        CREATE TABLE race_results (
+            result_id VARCHAR, event_name VARCHAR, event_id VARCHAR,
+            season INTEGER, location VARCHAR, year INTEGER,
+            division VARCHAR, gender VARCHAR, age_group VARCHAR,
+            total_time_min DOUBLE
+        );
+        """
+    )
+    con.executemany(
+        "INSERT INTO race_results VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("r1", "London Open", "e1", 8, "london", 2024, "open", "F", "30-34", 60.0),
+            ("r2", "London Open", "e1", 8, "london", 2024, "open", "F", "30-34", 62.0),
+            ("r3", "London Open", "e1", 8, "london", 2024, "open", "M", "30-34", 55.0),
+            ("r4", "Paris Open", "e2", 8, "paris", 2024, "open", "F", "30-34", 63.0),
+            ("r5", "Berlin S7", "e3", 7, "berlin", 2023, "open", "M", "35-39", 58.0),
+        ],
+    )
+
+
+def test_list_races_returns_distinct_races_with_counts(tmp_path, monkeypatch):
+    db_path = tmp_path / "mcp-races.db"
+    con = _create_db(db_path)
+    _seed_races(con)
+    con.close()
+
+    monkeypatch.setenv("PYROX_DUCKDB_PATH", str(db_path))
+    result = mcp_tools.list_races()
+
+    assert result["count"] == 3
+    london = next(r for r in result["races"] if r["location"] == "london")
+    assert london["participant_count"] == 3
+
+
+def test_list_races_filters_by_season(tmp_path, monkeypatch):
+    db_path = tmp_path / "mcp-races-season.db"
+    con = _create_db(db_path)
+    _seed_races(con)
+    con.close()
+
+    monkeypatch.setenv("PYROX_DUCKDB_PATH", str(db_path))
+    result = mcp_tools.list_races(season=7)
+
+    assert result["count"] == 1
+    assert result["races"][0]["location"] == "berlin"
+
+
+def test_list_races_filters_by_gender(tmp_path, monkeypatch):
+    db_path = tmp_path / "mcp-races-gender.db"
+    con = _create_db(db_path)
+    _seed_races(con)
+    con.close()
+
+    monkeypatch.setenv("PYROX_DUCKDB_PATH", str(db_path))
+    result = mcp_tools.list_races(gender="female")
+
+    assert result["count"] == 2
+    locations = {r["location"] for r in result["races"]}
+    assert locations == {"london", "paris"}
+
+
+def _seed_race_summary(con: duckdb.DuckDBPyConnection) -> None:
+    con.execute(
+        """
+        CREATE TABLE race_results (
+            result_id VARCHAR, event_name VARCHAR, event_id VARCHAR,
+            season INTEGER, location VARCHAR, year INTEGER,
+            division VARCHAR, gender VARCHAR, age_group VARCHAR,
+            total_time_min DOUBLE,
+            run_time_min DOUBLE, work_time_min DOUBLE, roxzone_time_min DOUBLE,
+            run1_time_min DOUBLE, skiErg_time_min DOUBLE
+        );
+        """
+    )
+    rows = []
+    for i in range(1, 21):
+        rows.append((
+            f"r{i}", "London Open", "e1", 8, "london", 2024,
+            "open", "F", "30-34",
+            50.0 + i,
+            25.0 + i * 0.5, 20.0 + i * 0.3, 5.0 + i * 0.2,
+            3.0 + i * 0.1, 4.0 + i * 0.1,
+        ))
+    con.executemany(
+        "INSERT INTO race_results VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+
+
+def test_get_race_summary_returns_segment_stats(tmp_path, monkeypatch):
+    db_path = tmp_path / "mcp-summary.db"
+    con = _create_db(db_path)
+    _seed_race_summary(con)
+    con.close()
+
+    monkeypatch.setenv("PYROX_DUCKDB_PATH", str(db_path))
+    result = mcp_tools.get_race_summary(season=8, location="london")
+
+    assert result["total_count"] == 20
+    assert result["filtered_count"] == 20
+    assert result["percentile_threshold_min"] is None
+    keys = [s["key"] for s in result["segments"]]
+    assert "total_time_min" in keys
+    total_seg = next(s for s in result["segments"] if s["key"] == "total_time_min")
+    assert total_seg["stats"]["count"] == 20
+    assert "mean" in total_seg["stats"]
+    assert "median" in total_seg["stats"]
+    assert "p10" in total_seg["stats"]
+
+
+def test_get_race_summary_percentile_filter(tmp_path, monkeypatch):
+    db_path = tmp_path / "mcp-summary-pct.db"
+    con = _create_db(db_path)
+    _seed_race_summary(con)
+    con.close()
+
+    monkeypatch.setenv("PYROX_DUCKDB_PATH", str(db_path))
+    result = mcp_tools.get_race_summary(season=8, location="london", top_percentile=10)
+
+    assert result["total_count"] == 20
+    assert result["filtered_count"] < 20
+    assert result["percentile_threshold_min"] is not None
+
+
+def test_get_race_summary_not_found(tmp_path, monkeypatch):
+    db_path = tmp_path / "mcp-summary-nf.db"
+    con = _create_db(db_path)
+    _seed_race_summary(con)
+    con.close()
+
+    monkeypatch.setenv("PYROX_DUCKDB_PATH", str(db_path))
+    result = mcp_tools.get_race_summary(season=99, location="nonexistent")
+
+    assert "error" in result
+    assert result["status_code"] == 404
+
+
 def test_mcp_server_registers_expected_tools():
     """The MCP server should expose exactly the annotated intent-shaped tool set."""
     import asyncio
@@ -189,8 +329,10 @@ def test_mcp_server_registers_expected_tools():
     names = {tool.name for tool in tools}
     assert names == {
         "list_filters",
+        "list_races",
         "find_athlete",
         "get_distribution",
+        "get_race_summary",
         "get_rankings",
         "get_race_report",
         "get_deepdive",


### PR DESCRIPTION
## Summary

- **`list_races`**: New MCP tool to discover distinct race events with participant counts, filterable by season and gender
- **`get_race_summary`**: New MCP tool returning summary stats (count, min, max, mean, median, p10, p90) across all timing segments for a specific race, with optional `top_percentile` filtering for fastest-N% cohort analysis (e.g. "median times of the top 10% in London")
- Added maintainer guide (`docs/maintainers/adding-mcp-tools.md`) documenting how to add future MCP tools

## Test plan

- [x] All 13 MCP tool tests pass (`pytest tests/test_mcp_tools.py -v`)
- [x] Full test suite shows no regressions (105 passed)
- [x] Smoke test expected tool set updated
- [x] Tool registration test updated to assert 9 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kNgQ7KVHMRqsomHCkttq5

---
_Generated by [Claude Code](https://claude.ai/code/session_014kNgQ7KVHMRqsomHCkttq5)_