### PR TITLE
fix(fly): persist DuckDB artifact on a volume to stop the cold-boot download loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ RUN pip install --no-cache-dir uv \
 
 EXPOSE 8080
 
-ENV PYROX_DUCKDB_PATH=/app/pyrox_duckdb
+# On Fly a persistent volume is mounted at /data (see fly.toml [mounts]); create
+# the dir so non-Fly/local runs without the mount still have a valid target.
+RUN mkdir -p /data
+ENV PYROX_DUCKDB_PATH=/data/pyrox_duckdb
 
 # The DuckDB artifact is no longer baked into the image: the scraping pipeline
 # publishes it to S3/CDN and fetch_db downloads + checksum-verifies it on boot,

--- a/fly.toml
+++ b/fly.toml
@@ -5,7 +5,11 @@ primary_region = "lhr"
   dockerfile = "Dockerfile"
 
 [env]
-  PYROX_DUCKDB_PATH = "/app/pyrox_duckdb"
+  # Store the DuckDB artifact on the persistent volume (see [mounts]) so it
+  # survives machine stops. fetch_db skips the download when the local file
+  # already matches the pointer's sha256, so only the first cold boot (or a new
+  # publish) pays the ~1.16GB download; later cold boots start in seconds.
+  PYROX_DUCKDB_PATH = "/data/pyrox_duckdb"
   # latest.json pointer published by the hyrox_analysis pipeline; fetch_db
   # downloads and checksum-verifies the referenced artifact on boot.
   PYROX_DB_POINTER_URL = "https://d2wl4b7sx66tfb.cloudfront.net/db/latest.json"
@@ -24,3 +28,13 @@ primary_region = "lhr"
   auto_stop_machines = "stop"
   auto_start_machines = true
   min_machines_running = 0
+
+# Persist the downloaded DuckDB artifact across machine stops. Without this the
+# rootfs is wiped on every stop, so each cold boot re-downloaded the full
+# ~1.16GB DB (~5 min) and Fly's auto-stop killed the machine mid-download before
+# uvicorn could bind -> boot loop. The volume lets fetch_db's sha256 skip-logic
+# reuse the artifact. The volume must be created once before deploy:
+#   fly volumes create pyrox_data --region lhr --size 3 -a pyrox-api
+[mounts]
+  source = "pyrox_data"
+  destination = "/data"


### PR DESCRIPTION
## Problem

`pyrox-api` couldn't finish a cold boot. Traced from Fly logs + machine events:

- Boot is `python -m pyrox_api_service.fetch_db && exec uvicorn ...`.
- `fetch_db` writes the DB to `PYROX_DUCKDB_PATH` on the **ephemeral rootfs**, which is wiped on every stop.
- So every cold boot re-downloads the full **~1.16 GB** artifact (~5 min). uvicorn can't bind until it finishes, so nothing listens on `:8080`, and Fly's auto-stop proxy stops the machine **mid-download** (`requested_stop=true, source=proxy`) → restart → re-download → **infinite loop**. The app never served.

(This is downstream of, but separate from, the CDN origin-path fix in hyrox_analysis #25 that resolved the original 403 — the pointer/artifact now serve 200 and `fetch_db` downloads fine; it just couldn't persist it.)

## Fix

Mount a persistent Fly volume at `/data` and point `PYROX_DUCKDB_PATH` at `/data/pyrox_duckdb`. `fetch_db` already skips the download when the local file matches the pointer's sha256 (that skip-logic was dead because the file never survived). Now:

- first cold boot (or a new publish, when the sha changes) downloads once;
- every later cold boot finds the file, verifies sha256, and starts uvicorn in seconds — before auto-stop can fire.

`auto_stop_machines` / `min_machines_running` are **unchanged** (no always-on machine). `tmp_target` and `target` both live under `/data`, so `fetch_db`'s `os.replace` stays atomic (same filesystem). Dockerfile `mkdir -p /data` keeps non-Fly/local runs valid.

## One-time setup before deploy

The volume must exist before `fly deploy` (the `[mounts]` references it by name):
```
fly volumes create pyrox_data --region lhr --size 3 -a pyrox-api
```
Size 3 GB gives headroom for the artifact (~1.16 GB) plus the transient `.download` temp during a refresh.

## Follow-up (not here)
`fetch_db && uvicorn` still hard-gates the app on the fetch. Decoupling (start uvicorn, download in background, 503 until ready) would make even the first boot resilient. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)