### PR TITLE
chore: license project under MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vlad Matei
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ Maintainer-only operational docs:
 - `docs/maintainers/release.md`
 - `docs/maintainers/reporting-service.md`
 
+## License
+
+Released under the [MIT License](LICENSE) — free to use, modify, and distribute. Copyright (c) 2026 Vlad Matei.
+
 ## Disclaimer
 
 Pyrox is an independent project and is not affiliated with, endorsed, or sponsored by HYROX.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ dynamic = ["version"]
 description = "HYROX race data client – retrieve full race results via Python"
 authors = [{ name = "Vlad Matei" }]
 readme = {file="README.md", content-type = "text/markdown" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 dependencies = [
     "pandas>=2.3.3",
@@ -31,12 +33,6 @@ api = [
     "numpy>=1.26.4",
     "uvicorn[standard]>=0.30.0",
 ]
-
-# classifiers = [
-#   "Programming Language :: Python :: 3.12",
-#   "License :: OSI Approved :: MIT License",
-#   "Operating System :: OS Independent",
-# ]
 
 # urls."Homepage" = "https://github.com/vmatei2/pyrox-client"
 # urls."Issues"   = "https://github.com/vmatei2/pyrox-client/issues"


### PR DESCRIPTION
## What
Makes pyrox-client an actual open-source project under the **MIT** license.

- Adds a top-level `LICENSE` file (MIT, Copyright (c) 2026 Vlad Matei).
- Declares it in `pyproject.toml` via the PEP 639 SPDX form:
  ```toml
  license = "MIT"
  license-files = ["LICENSE"]
  ```
- Removes the stale, commented-out `classifiers` block (its `License :: OSI Approved :: MIT License` entry is redundant with — and deprecated in favour of — the SPDX expression).

## Why
The project had **no license declared anywhere** — no `LICENSE` file, and the license classifier was commented out. Under default copyright law that means *all rights reserved*, not open source: consumers had no legal right to use, copy, or redistribute it, and dependency scanners flag unlicensed packages.

## Verification
Built the wheel locally — metadata now carries:
```
License-Expression: MIT
License-File: LICENSE
```
and the `LICENSE` file is bundled under `*.dist-info/licenses/`.