### PR TITLE
Support Workout Summary place fields

### DIFF
--- a/codewiki_docs/overview.md
+++ b/codewiki_docs/overview.md
@@ -91,7 +91,9 @@ edition for that season and location.
 
 These paths have related but different schemas. Do not assume a column name
 from CDN Parquet is identical to the reporting database's canonical
-`*_time_min` columns.
+`*_time_min` columns. `PyroxClient.get_race()` maps raw Workout Summary times
+and places onto paired public names such as `skiErg_time` / `skiErg_place` and
+`run1_time` / `run1_place`.
 
 ### REST reporting
 
@@ -159,7 +161,9 @@ business-logic implementation.
   connectors send Origin headers and the service is already public,
   read-only, and behind Fly HTTPS.
 - The service refuses a data artifact whose schema version is newer than
-  [`SUPPORTED_SCHEMA_VERSION`](../pyrox_api_service/fetch_db.py).
+  [`SUPPORTED_SCHEMA_VERSION`](../pyrox_api_service/fetch_db.py). It currently
+  accepts schema version 3, which adds Workout Summary place fields and Best
+  Run Lap without changing `result_id` or existing reporting columns.
 
 ## Change this here
 

--- a/docs/duckdb-stabilization.md
+++ b/docs/duckdb-stabilization.md
@@ -7,7 +7,7 @@ artifact on boot via `pyrox_api_service/fetch_db.py`, and refuses pointers
 whose `schema_version` is newer than `fetch_db.SUPPORTED_SCHEMA_VERSION`. The
 artifact stamps a `build_info` table (schema_version, built_at, source S3 URI).
 
-## Schema Contracts (v1)
+## Schema Contracts (v3)
 Source of truth: `scraping_code/db_build/sql_queries.py` and
 `scraping_code/db_build/ingest.py` in the `hyrox_analysis` repository.
 
@@ -29,6 +29,7 @@ stable keys and search; other fields may be NULL depending on source data.
   - `gender` VARCHAR
   - `name_raw` VARCHAR
   - `nationality` VARCHAR
+  - `source_result_id` VARCHAR
 - Time string columns (VARCHAR, nullable):
   - `roxzone_time`
   - `run1_time`, `run2_time`, `run3_time`, `run4_time`,
@@ -37,6 +38,7 @@ stable keys and search; other fields may be NULL depending on source data.
   - `skiErg_time`, `sledPush_time`, `sledPull_time`, `burpeeBroadJump_time`,
     `rowErg_time`, `farmersCarry_time`, `sandbagLunges_time`, `wallBalls_time`
   - `work_time`
+  - `bestRunLap_time`
 - Time numeric columns (DOUBLE, nullable; minutes):
   - `roxzone_time_min`
   - `run1_time_min`, `run2_time_min`, `run3_time_min`, `run4_time_min`,
@@ -46,6 +48,14 @@ stable keys and search; other fields may be NULL depending on source data.
     `burpeeBroadJump_time_min`, `rowErg_time_min`, `farmersCarry_time_min`,
     `sandbagLunges_time_min`, `wallBalls_time_min`
   - `work_time_min`
+  - `bestRunLap_time_min`
+- Workout Summary place columns (BIGINT, nullable):
+  - `roxzone_place`, `run_place`, `bestRunLap_place`
+  - `run1_place`, `run2_place`, `run3_place`, `run4_place`,
+    `run5_place`, `run6_place`, `run7_place`, `run8_place`
+  - `skiErg_place`, `sledPush_place`, `sledPull_place`,
+    `burpeeBroadJump_place`, `rowErg_place`, `farmersCarry_place`,
+    `sandbagLunges_place`, `wallBalls_place`
 
 ### athletes
 Derived from `race_results` (canonical identity).

--- a/pyrox_api_service/fetch_db.py
+++ b/pyrox_api_service/fetch_db.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 # Highest artifact schema this service understands; the pipeline bumps the
 # pointer's schema_version on breaking changes and we refuse to serve those.
-SUPPORTED_SCHEMA_VERSION = 2
+SUPPORTED_SCHEMA_VERSION = 3
 
 DEFAULT_POINTER_URL = "https://d2wl4b7sx66tfb.cloudfront.net/db/latest.json"
 POINTER_URL_ENV = "PYROX_DB_POINTER_URL"

--- a/src/pyrox/constants.py
+++ b/src/pyrox/constants.py
@@ -23,3 +23,15 @@ WORK_STATION_RENAMES = {
     "run_7": "run7_time",
     "run_8": "run8_time",
 }
+
+WORKOUT_SUMMARY_RENAMES = {
+    **WORK_STATION_RENAMES,
+    **{
+        f"{source}_place": f"{target.removesuffix('_time')}_place"
+        for source, target in WORK_STATION_RENAMES.items()
+    },
+    "roxzone_time_place": "roxzone_place",
+    "run_time_place": "run_place",
+    "best_run_lap": "bestRunLap_time",
+    "best_run_lap_place": "bestRunLap_place",
+}

--- a/src/pyrox/core.py
+++ b/src/pyrox/core.py
@@ -486,13 +486,14 @@ class PyroxClient:
             ) from e
 
         # Before returning, convert station columns to their exercise names
-        df = df.rename(columns=_ct.WORK_STATION_RENAMES)
+        df = df.rename(columns=_ct.WORKOUT_SUMMARY_RENAMES)
 
         time_cols = list(_ct.WORK_STATION_RENAMES.values()) + [
             "total_time",
             "work_time",
             "roxzone_time",
             "run_time",
+            "bestRunLap_time",
         ]
 
         for col in time_cols:

--- a/tests/test_client_core.py
+++ b/tests/test_client_core.py
@@ -72,6 +72,44 @@ def test_get_race_from_s3_when_not_cache(client, sample_race_data):
     assert_frame_equal(result, expected)
 
 
+def test_get_race_maps_workout_summary_places_beside_their_times(client):
+    raw = pd.DataFrame(
+        [
+            {
+                "name": "Alex Athlete",
+                "work_1": "04:00",
+                "work_1_place": 1,
+                "run_1": "04:30",
+                "run_1_place": None,
+                "roxzone_time_place": 8,
+                "run_time_place": 12,
+                "best_run_lap": "03:45",
+                "best_run_lap_place": 26,
+            }
+        ]
+    )
+
+    with (
+        patch.object(client.cache, "is_fresh", return_value=False),
+        patch.object(client, "_get_race_from_cdn", return_value=raw),
+    ):
+        result = client.get_race(
+            season=9,
+            location="Bangkok",
+            use_cache=False,
+        )
+
+    row = result.iloc[0]
+    assert row["skiErg_time"] == 4.0
+    assert row["skiErg_place"] == 1
+    assert row["run1_time"] == 4.5
+    assert pd.isna(row["run1_place"])
+    assert row["roxzone_place"] == 8
+    assert row["run_place"] == 12
+    assert row["bestRunLap_time"] == 3.75
+    assert row["bestRunLap_place"] == 26
+
+
 def test_get_race_without_year_combines_all_location_editions(client):
     manifest_rows = [
         {

--- a/tests/test_fetch_db.py
+++ b/tests/test_fetch_db.py
@@ -53,10 +53,11 @@ def test_parse_pointer_happy_path():
     )
 
 
-def test_parse_pointer_accepts_current_schema_v2():
-    pointer = parse_pointer(_pointer_payload(schema_version=2))
+def test_parse_pointer_accepts_current_schema_v3():
+    pointer = parse_pointer(_pointer_payload(schema_version=3))
 
-    assert pointer.schema_version == 2
+    assert SUPPORTED_SCHEMA_VERSION == 3
+    assert pointer.schema_version == 3
 
 
 @pytest.mark.parametrize("missing", ["key", "sha256", "size_bytes", "schema_version"])


### PR DESCRIPTION
## Purpose
Prepare pyrox-client for the additive DuckDB schema v3 Workout Summary fields requested in vmatei2/pyrox-client#43.

## Approach
- accept schema-v3 database pointers while retaining v2 compatibility
- map raw summary place columns beside their existing time counterparts
- document the v3 reporting contract and rollout ordering

## Testing
- `.venv/bin/python -m pytest -q` — 136 passed, 3 skipped
- Ruff checks passed
- exact producer-built schema-v3 artifact passed ReportingClient race report and FastAPI health, races, and report routes