### PR TITLE
Automate weekly data promotion

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -1,11 +1,8 @@
 name: Refresh Data
 
-# The hyrox_analysis pipeline publishes a new DuckDB artifact to S3 weekly
-# (scraper starts Tuesday 12:00 UTC; its job is capped at 6h, so the artifact
-# is live by ~18:30 UTC). Restarting the machines afterwards makes them re-run
-# fetch_db on boot and pick up the new artifact; no image rebuild. Machines
-# that were stopped (auto_stop + min_machines_running = 0) fetch it on their
-# next cold start anyway — this schedule only covers machines that stayed warm.
+# hyrox_analysis publishes a validated candidate as latest.json. This weekly
+# consumer job promotes a supported, changed candidate to deploy-current.json,
+# then refreshes Fly. The service never reads latest.json directly.
 
 on:
   schedule:
@@ -16,21 +13,119 @@ concurrency:
   group: refresh-data
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   refresh:
     runs-on: ubuntu-latest
     env:
+      AWS_REGION: ${{ secrets.S3_REGION }}
+      S3_BUCKET: hyrox-results
+      CANDIDATE_POINTER_KEY: processed/db/latest.json
+      PRODUCTION_POINTER_KEY: processed/db/deploy-current.json
+      FLY_APP: pyrox-api
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      HEALTH_URL: https://pyrox-api.fly.dev/api/health
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install pointer validation dependencies
+        run: uv pip install --system -e .
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download candidate and production pointers
+        run: |
+          aws s3 cp \
+            "s3://${S3_BUCKET}/${CANDIDATE_POINTER_KEY}" \
+            candidate-pointer.json \
+            --no-progress
+          aws s3 cp \
+            "s3://${S3_BUCKET}/${PRODUCTION_POINTER_KEY}" \
+            production-pointer.json \
+            --no-progress
+
+      - name: Validate candidate and decide whether to promote
+        id: promotion
+        run: |
+          python -m scripts.data_promotion \
+            --candidate candidate-pointer.json \
+            --current production-pointer.json \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: No new artifact to promote
+        if: steps.promotion.outputs.promote != 'true'
+        run: echo "Production already references the candidate SHA; nothing to do."
+
+      # Upload the exact local JSON that was validated above, rather than
+      # copying a potentially newer latest.json after the validation step.
+      - name: Promote candidate pointer
+        if: steps.promotion.outputs.promote == 'true'
+        run: |
+          aws s3api put-object \
+            --bucket "$S3_BUCKET" \
+            --key "$PRODUCTION_POINTER_KEY" \
+            --body candidate-pointer.json \
+            --content-type application/json \
+            --cache-control "no-cache, max-age=0, must-revalidate"
+
       - name: Set up Flyctl
+        if: steps.promotion.outputs.promote == 'true'
         uses: superfly/flyctl-actions/setup-flyctl@master
 
-      # A restart failure on stopped machines is not worth failing the
-      # refresh over; the next cold start fetches the new artifact.
-      - name: Restart machines to pick up new artifact
+      - name: Restart or wake Fly machines
+        if: steps.promotion.outputs.promote == 'true'
         run: |
-          flyctl apps restart pyrox-api \
-            || echo "restart failed (machines may be stopped); next cold start fetches the new artifact"
+          machines="$(flyctl machines list --app "$FLY_APP" --json)"
+          if [ "$(jq 'length' <<< "$machines")" -eq 0 ]; then
+            echo "No Fly machines found for $FLY_APP" >&2
+            exit 1
+          fi
+
+          while IFS=$'\t' read -r machine_id machine_state; do
+            case "$machine_state" in
+              started)
+                flyctl machine restart "$machine_id" --app "$FLY_APP"
+                ;;
+              stopped)
+                flyctl machine start "$machine_id" --app "$FLY_APP"
+                ;;
+              *)
+                echo "Cannot refresh machine $machine_id in state $machine_state" >&2
+                exit 1
+                ;;
+            esac
+          done < <(jq -r '.[] | [.id, .state] | @tsv' <<< "$machines")
+
+      - name: Verify live API health
+        if: steps.promotion.outputs.promote == 'true'
+        run: |
+          deadline=$((SECONDS + 720))
+          until curl \
+            --fail \
+            --silent \
+            --show-error \
+            --max-time 20 \
+            "$HEALTH_URL" \
+            --output health.json \
+            && jq -e '.status == "ok"' health.json; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "API did not become healthy within 12 minutes" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+          jq . health.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@
 - Service configuration comes from env variables (`PYROX_DUCKDB_PATH` and friends; see `docs/maintainers/reporting-service.md`). Avoid committing secrets; use `.env` locally and CI secrets in pipelines.
 - Network calls use `httpx`; set reasonable timeouts and retries in changes. Keep error surfaces mapped to `errors.py` types.
 
+## Production Data Promotion
+- `hyrox_analysis` owns the candidate pointer at `latest.json`; do not update it from this repository.
+- The live API reads `deploy-current.json`. Promote candidates only through `.github/workflows/refresh-data.yml`; never point Fly directly at `latest.json`.
+
 ## Architecture Map
 
 Read `codewiki_docs/overview.md` before substantial code work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,7 @@ force an edit after every code change.
 
 When sources disagree, precedence is: code and tests, user/maintainer `docs/`,
 then `codewiki_docs/overview.md`.
+
+For production data, `hyrox_analysis` owns the candidate `latest.json`; this
+repository promotes it to `deploy-current.json` through the Refresh Data
+workflow. Never point Fly directly at `latest.json`.

--- a/codewiki_docs/overview.md
+++ b/codewiki_docs/overview.md
@@ -16,8 +16,18 @@ disagree, trust code and tests first, then `docs/`, then this overview.
 flowchart LR
     subgraph upstream ["External data pipeline"]
         SCRAPE["hyrox_analysis<br/>scrape and build"]
-        CDN["CloudFront<br/>manifest, Parquet, DuckDB pointer"]
+        CANDIDATE["S3 latest.json<br/>candidate pointer"]
+        CDN["CloudFront<br/>manifest, Parquet, DuckDB"]
+        SCRAPE --> CANDIDATE
         SCRAPE --> CDN
+    end
+
+    subgraph promotion ["Weekly production promotion"]
+        REFRESH["Refresh Data workflow<br/>validate and compare SHA"]
+        PRODUCTION["S3 deploy-current.json<br/>production pointer"]
+        CANDIDATE --> REFRESH
+        REFRESH --> PRODUCTION
+        PRODUCTION --> CDN
     end
 
     subgraph package ["Published Python package"]
@@ -68,10 +78,13 @@ client's Parquet path is independent of the hosted service.
 
 The repository consumes race data but does not scrape or build the production
 DuckDB database. The external `hyrox_analysis` pipeline publishes immutable
-artifacts and a `latest.json` pointer. On service boot,
-[`fetch_db.py`](../pyrox_api_service/fetch_db.py) downloads the referenced
-artifact, checks its schema version and SHA-256, then atomically installs it at
-`PYROX_DUCKDB_PATH`.
+artifacts and the candidate `latest.json` pointer. This repository's weekly
+[`Refresh Data`](../.github/workflows/refresh-data.yml) workflow validates a
+changed candidate and copies that exact JSON to the consumer-owned
+`deploy-current.json` pointer before refreshing Fly. On service boot,
+[`fetch_db.py`](../pyrox_api_service/fetch_db.py) downloads only the production
+pointer's artifact, checks its schema version and SHA-256, then atomically
+installs it at `PYROX_DUCKDB_PATH`.
 
 ## Runtime paths
 
@@ -156,6 +169,10 @@ business-logic implementation.
   are exempt from double charging.
 - The Fly machine may stop when idle. The persistent `/data` volume prevents a
   full DuckDB download on every cold start.
+- `latest.json` is producer-owned candidate state; `deploy-current.json` is the
+  consumer-owned live contract. The Tuesday 20:00 UTC refresh workflow promotes
+  only a changed pointer accepted by this service's schema-version guard, then
+  requires the restarted or awakened API to pass `/api/health`.
 - `PYROX_MCP_ALLOWED_HOSTS` enables MCP Host/Origin validation. It is
   intentionally unset for the public Fly endpoint because browser/Electron
   connectors send Origin headers and the service is already public,
@@ -177,6 +194,7 @@ business-logic implementation.
 | New MCP tool | [maintainer guide](../docs/maintainers/adding-mcp-tools.md) | REST route first, then tool, registration, tests, smoke script |
 | UI mode or chart | [`ui/src/pages/`](../ui/src/pages/) or [`ui/src/charts/`](../ui/src/charts/) | API client and Vitest coverage |
 | Service boot or deployment | [`Dockerfile`](../Dockerfile), [`fly.toml`](../fly.toml) | [reporting runbook](../docs/maintainers/reporting-service.md) |
+| Production data promotion | [`refresh-data.yml`](../.github/workflows/refresh-data.yml) | pointer parser, Fly configuration, and reporting runbook |
 
 ## Build, test, and deploy
 
@@ -201,8 +219,10 @@ Pushes to `main` run Python tests and integration checks. The
 automatically only when backend/package code, `Dockerfile`, `fly.toml`,
 `pyproject.toml`, or that workflow changes. Documentation-only and UI-only
 commits do not trigger the API deploy. Tagged `v*` commits build and publish the
-Python package to PyPI. A weekly workflow restarts Fly machines after the
-upstream data publish so warm machines fetch the new artifact.
+Python package to PyPI. The weekly refresh workflow promotes a supported
+candidate pointer after the upstream data publish, refreshes every Fly machine,
+and waits for the live health check. Its manual trigger handles out-of-cycle
+backfills.
 
 There is no UI deployment workflow in this repository; the Vite and Capacitor
 builds are configured here, while hosting/release automation lives elsewhere.

--- a/docs/duckdb-stabilization.md
+++ b/docs/duckdb-stabilization.md
@@ -2,10 +2,12 @@
 
 The database build lives in the upstream `hyrox_analysis` repository
 (`scraping_code/db_build/`), which publishes an immutable artifact plus a
-`latest.json` pointer to S3. This service downloads and checksum-verifies the
-artifact on boot via `pyrox_api_service/fetch_db.py`, and refuses pointers
-whose `schema_version` is newer than `fetch_db.SUPPORTED_SCHEMA_VERSION`. The
-artifact stamps a `build_info` table (schema_version, built_at, source S3 URI).
+candidate `latest.json` pointer to S3. The weekly consumer workflow promotes a
+supported candidate to `deploy-current.json`; this service downloads and
+checksum-verifies that production artifact on boot via
+`pyrox_api_service/fetch_db.py`, and refuses pointers whose `schema_version` is
+newer than `fetch_db.SUPPORTED_SCHEMA_VERSION`. The artifact stamps a
+`build_info` table (schema_version, built_at, source S3 URI).
 
 ## Schema Contracts (v3)
 Source of truth: `scraping_code/db_build/sql_queries.py` and

--- a/docs/maintainers/reporting-service.md
+++ b/docs/maintainers/reporting-service.md
@@ -85,16 +85,23 @@ with `PYROX_RATE_LIMIT` (a
 ## Data Flow
 
 The DuckDB artifact is built and published by the `hyrox_analysis` repository
-(scrape → build → verify → publish to `s3://hyrox-results/db/` with a
-`latest.json` pointer). This service is a pure consumer:
-`pyrox_api_service/fetch_db.py` downloads the pointer, verifies the artifact's
-sha256, and swaps it into place on container boot. Stopped machines therefore
-pick up new data on their next cold start; `.github/workflows/refresh-data.yml`
-additionally restarts any warm machines on a weekly schedule (after the
-upstream Tuesday publish) — no image rebuild, no cross-repo credentials.
-Code deploys are handled separately by
-`.github/workflows/deploy.yml`. To roll data back, repoint `latest.json` at an
-earlier artifact in `s3://hyrox-results/db/` and restart the machines.
+(scrape → build → verify → publish to `s3://hyrox-results/processed/db/`). The
+producer owns `latest.json`, which is a candidate pointer rather than the live
+service contract.
+
+At 20:00 UTC each Tuesday, `.github/workflows/refresh-data.yml` reads the
+candidate and `deploy-current.json` directly from S3. It validates both with
+the consumer's pointer parser and exits without touching Fly when their SHA-256
+values match. For a supported new candidate, it writes the exact validated JSON
+to `deploy-current.json`, then restarts or wakes the Fly machine and waits up to
+12 minutes for `/api/health`. The workflow can also be dispatched manually for
+an out-of-cycle backfill.
+
+`pyrox_api_service/fetch_db.py` reads only the production pointer, verifies the
+artifact's SHA-256, and swaps it into place on container boot. Code deploys are
+handled separately by `.github/workflows/deploy.yml`. To roll data back,
+repoint `deploy-current.json` at an earlier immutable artifact and refresh the
+Fly machine; do not change the producer-owned `latest.json` from this repo.
 
 ## Backend: Local Run
 
@@ -139,7 +146,7 @@ npx cap open ios
 - Fly configuration is in `fly.toml`.
 - Environment variables used by the service:
   - `PYROX_DUCKDB_PATH`
-  - `PYROX_DB_POINTER_URL` — URL of the pipeline-published `latest.json`
+  - `PYROX_DB_POINTER_URL` — URL of the consumer-owned `deploy-current.json`
     pointer that `fetch_db` resolves on boot (defaults to the public CDN).
   - `PYROX_API_ALLOW_ORIGINS`
   - `PYROX_MCP_ALLOWED_HOSTS` (optional) — comma-separated Host allow-list. When

--- a/fly.toml
+++ b/fly.toml
@@ -10,9 +10,9 @@ primary_region = "lhr"
   # already matches the pointer's sha256, so only the first cold boot (or a new
   # publish) pays the ~1.16GB download; later cold boots start in seconds.
   PYROX_DUCKDB_PATH = "/data/pyrox_duckdb"
-  # latest.json pointer published by the hyrox_analysis pipeline; fetch_db
-  # downloads and checksum-verifies the referenced artifact on boot.
-  PYROX_DB_POINTER_URL = "https://d2wl4b7sx66tfb.cloudfront.net/db/latest.json"
+  # Consumer-owned production pointer. The weekly refresh workflow promotes
+  # validated candidates from latest.json before machines read them here.
+  PYROX_DB_POINTER_URL = "https://d2wl4b7sx66tfb.cloudfront.net/db/deploy-current.json"
   PYROX_API_ALLOW_ORIGINS = "https://pyrox-analytics.vercel.app,capacitor://localhost,ionic://localhost,http://localhost"
   # MCP DNS-rebinding protection is intentionally left off here. It validates the
   # Host/Origin headers and exists to stop a malicious site pivoting through a

--- a/pyrox_api_service/fetch_db.py
+++ b/pyrox_api_service/fetch_db.py
@@ -1,17 +1,18 @@
 """Boot-time fetch of the DuckDB artifact published by the scraping pipeline.
 
 The hyrox_analysis repo builds the database and publishes it to S3 as an
-immutable object plus a ``latest.json`` pointer (key, sha256, schema_version,
-provenance). This module downloads the pointer, verifies the artifact
-checksum, and atomically swaps the file into place before the API starts.
-The service itself never builds or ingests data.
+immutable object plus a candidate pointer. The pyrox-client refresh workflow
+promotes supported candidates to ``deploy-current.json``. This module downloads
+that production pointer, verifies the artifact checksum, and atomically swaps
+the file into place before the API starts. The service itself never builds or
+ingests data.
 
 Run as a container entrypoint step:
 
     python -m pyrox_api_service.fetch_db && uvicorn pyrox_api_service.mcp_app:app ...
 
 Environment:
-    PYROX_DB_POINTER_URL  URL of latest.json (default: the public CDN pointer)
+    PYROX_DB_POINTER_URL  URL of deploy-current.json (default: the public CDN pointer)
     PYROX_DUCKDB_PATH     where to place the artifact (default: pyrox_duckdb)
 """
 
@@ -34,7 +35,7 @@ logger = logging.getLogger(__name__)
 # pointer's schema_version on breaking changes and we refuse to serve those.
 SUPPORTED_SCHEMA_VERSION = 3
 
-DEFAULT_POINTER_URL = "https://d2wl4b7sx66tfb.cloudfront.net/db/latest.json"
+DEFAULT_POINTER_URL = "https://d2wl4b7sx66tfb.cloudfront.net/db/deploy-current.json"
 POINTER_URL_ENV = "PYROX_DB_POINTER_URL"
 DUCKDB_PATH_ENV = "PYROX_DUCKDB_PATH"
 
@@ -55,7 +56,7 @@ class ArtifactPointer:
 
 
 def parse_pointer(payload: dict[str, Any]) -> ArtifactPointer:
-    """Validate the latest.json payload and return the pointer contract."""
+    """Validate a pointer payload and return the artifact contract."""
     for field in ("key", "sha256", "size_bytes", "schema_version"):
         if field not in payload:
             raise ArtifactFetchError(f"pointer is missing required field: {field}")

--- a/scripts/data_promotion.py
+++ b/scripts/data_promotion.py
@@ -1,0 +1,94 @@
+"""Assess whether a candidate DuckDB pointer should be promoted.
+
+The upstream ``hyrox_analysis`` pipeline owns ``latest.json``. This helper is
+used by the consumer's refresh workflow to validate that candidate against the
+pointer contract understood by the running service and to decide whether its
+SHA differs from ``deploy-current.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from pyrox_api_service.fetch_db import ArtifactPointer, parse_pointer
+
+
+@dataclass(frozen=True)
+class PromotionDecision:
+    """Validated candidate/current pointers and the resulting action."""
+
+    candidate: ArtifactPointer
+    current: ArtifactPointer
+    promote: bool
+
+
+def load_pointer(path: Path) -> dict[str, Any]:
+    """Read a pointer JSON object from ``path`` with a clear validation error."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read pointer JSON from {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"pointer JSON in {path} must be an object")
+    return payload
+
+
+def assess_promotion(
+    candidate_payload: Mapping[str, Any],
+    current_payload: Mapping[str, Any],
+) -> PromotionDecision:
+    """Validate both pointers and promote only when their SHA-256 values differ."""
+    candidate = parse_pointer(dict(candidate_payload))
+    current = parse_pointer(dict(current_payload))
+    return PromotionDecision(
+        candidate=candidate,
+        current=current,
+        promote=candidate.sha256 != current.sha256,
+    )
+
+
+def _write_github_outputs(path: Path, decision: PromotionDecision) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"promote={'true' if decision.promote else 'false'}\n")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--current", required=True, type=Path)
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="Append workflow outputs to this GitHub Actions output file.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    decision = assess_promotion(
+        load_pointer(args.candidate),
+        load_pointer(args.current),
+    )
+    if args.github_output:
+        _write_github_outputs(args.github_output, decision)
+    print(
+        json.dumps(
+            {
+                "candidate": asdict(decision.candidate),
+                "current": asdict(decision.current),
+                "promote": decision.promote,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_data_promotion.py
+++ b/tests/test_data_promotion.py
@@ -1,0 +1,73 @@
+"""Tests for the weekly production-pointer promotion decision."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from pyrox_api_service.fetch_db import SUPPORTED_SCHEMA_VERSION, ArtifactFetchError
+from scripts.data_promotion import assess_promotion, load_pointer
+
+
+def _pointer(*, content: bytes = b"candidate", **overrides) -> dict:
+    payload = {
+        "key": "db/pyrox_duckdb_20260831T120000Z.duckdb",
+        "sha256": hashlib.sha256(content).hexdigest(),
+        "size_bytes": len(content),
+        "schema_version": SUPPORTED_SCHEMA_VERSION,
+        "built_at": "2026-08-31T12:00:00+00:00",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_unchanged_sha_is_a_no_op() -> None:
+    pointer = _pointer()
+
+    decision = assess_promotion(pointer, pointer)
+
+    assert decision.promote is False
+
+
+def test_different_sha_is_promotable() -> None:
+    candidate = _pointer(content=b"candidate")
+    current = _pointer(content=b"current")
+
+    decision = assess_promotion(candidate, current)
+
+    assert decision.promote is True
+    assert decision.candidate.sha256 == candidate["sha256"]
+
+
+def test_malformed_candidate_is_rejected() -> None:
+    candidate = _pointer()
+    del candidate["sha256"]
+
+    with pytest.raises(ArtifactFetchError, match="sha256"):
+        assess_promotion(candidate, _pointer(content=b"current"))
+
+
+def test_unsupported_candidate_schema_is_rejected() -> None:
+    candidate = _pointer(schema_version=SUPPORTED_SCHEMA_VERSION + 1)
+
+    with pytest.raises(ArtifactFetchError, match="newer than supported"):
+        assess_promotion(candidate, _pointer(content=b"current"))
+
+
+def test_invalid_json_is_rejected(tmp_path: Path) -> None:
+    pointer_path = tmp_path / "pointer.json"
+    pointer_path.write_text("not-json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="could not read pointer JSON"):
+        load_pointer(pointer_path)
+
+
+def test_non_object_json_is_rejected(tmp_path: Path) -> None:
+    pointer_path = tmp_path / "pointer.json"
+    pointer_path.write_text(json.dumps([_pointer()]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be an object"):
+        load_pointer(pointer_path)

--- a/tests/test_fetch_db.py
+++ b/tests/test_fetch_db.py
@@ -1,7 +1,7 @@
 """Tests for the boot-time DuckDB artifact fetch.
 
 The service no longer bakes the database into the image; it downloads the
-artifact referenced by the pipeline-published latest.json pointer.
+artifact referenced by the consumer-owned production pointer.
 """
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ import pytest
 import respx
 
 from pyrox_api_service.fetch_db import (
+    DEFAULT_POINTER_URL,
     SUPPORTED_SCHEMA_VERSION,
     ArtifactFetchError,
     ArtifactPointer,
@@ -22,7 +23,7 @@ from pyrox_api_service.fetch_db import (
     parse_pointer,
 )
 
-POINTER_URL = "https://cdn.example.com/db/latest.json"
+POINTER_URL = "https://cdn.example.com/db/deploy-current.json"
 DB_BYTES = b"duckdb artifact bytes"
 
 
@@ -51,6 +52,10 @@ def test_parse_pointer_happy_path():
         schema_version=SUPPORTED_SCHEMA_VERSION,
         built_at="2026-07-09T12:30:00+00:00",
     )
+
+
+def test_default_pointer_uses_consumer_owned_production_pointer():
+    assert DEFAULT_POINTER_URL.endswith("/db/deploy-current.json")
 
 
 def test_parse_pointer_accepts_current_schema_v3():


### PR DESCRIPTION
## Purpose

Promote the producer-owned `latest.json` candidate to the API-owned `deploy-current.json` pointer during the existing weekly refresh, without manual intervention.

## Approach

- validate candidate and production pointers with the existing consumer parser
- no-op when their SHA values already match
- otherwise upload the exact validated JSON, restart or wake Fly machines, and wait for API health
- align runtime defaults and operational documentation with the production pointer

## Testing

- `pytest -q` (143 passed, 3 skipped)
- `ruff check src pyrox_api_service scripts tests`
- GitHub workflow JSON-schema validation
- strict codewiki validation
- real workflow-dispatch no-op: https://github.com/vmatei2/pyrox-client/actions/runs/33425539010